### PR TITLE
Removed irrelevant local dev db password (pg has default local host trust by default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Azure Static Web App + local dev config flow
 ## Dev
 
 1. Start dev web server: `npm run start`
-1. Start local db via: `npm run db`
+1. Start local db via (in another terminal): `npm run db`
 1. Start dev Azure functions host (in another terminal): `npm run api`
 1. Start Azure Static Web App emulator (in another terminal): `npm run azure:emu`
-1. Hit webapp at `http://localhost:4280/`
-1. Hit api at `http://localhost:4280/api/`
+1. Hit webapp through emulator at `http://localhost:4280/`
+1. Hit api through emulator at `http://localhost:4280/api/`
 1. Reset db (data and password) via deleting Docker volume as specified in `db/start_dev.sh`
 
 ## Deployment

--- a/db/start_local_dev.sh
+++ b/db/start_local_dev.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 CONTAINER_NAME="ece-connect-db"
-DEV_PASSWORD="localdevpassword"
 VOLUME_NAME="db-volume"
 
 docker volume create $VOLUME_NAME ; docker kill $CONTAINER_NAME ; docker rm $CONTAINER_NAME ;
-docker run --name $CONTAINER_NAME --network host -p 5432:5432 -e POSTGRES_PASSWORD=$DEV_PASSWORD -v $VOLUME_NAME:/var/lib/postgresql/data:rw -d postgres:11
+docker run --name $CONTAINER_NAME --network host -p 5432:5432 -e POSTGRES_PASSWORD="IrreleventDueToHostTrust" \
+    -v $VOLUME_NAME:/var/lib/postgresql/data:rw -d postgres:11 
 docker logs -f $CONTAINER_NAME
 
 # Shell into db container:


### PR DESCRIPTION
pg has local host trust setup so by default we the postgres user can login without a password.

Removed local dev db password from startup script (and api local.settings.json) to avoid confusion.

Not an issue for live pg db.